### PR TITLE
add with-expect-call2 that allows unordered calls

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.0-alpha4"}
+        org.clojure/spec.alpha {:mvn/version "0.3.214"}
+        org.clojure/core.match {:mvn/version "0.2.2"}}}

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/spec.alpha "0.3.214"]
                  [org.clojure/core.match "0.2.2"]])

--- a/src/whitepages/expect_call.clj
+++ b/src/whitepages/expect_call.clj
@@ -1,10 +1,96 @@
 (ns whitepages.expect-call
-  (:require [whitepages.expect-call.internal :refer :all]))
+  (:require
+   [clojure.core.match :refer [match]]
+   [whitepages.expect-call.internal :refer :all]
+   [clojure.spec.alpha :as s]))
+
+(s/def ::expected-fn
+  (s/cat :tags (s/* #{:do :more :once :never})
+         :fdef (s/cat :fname symbol?
+                      :args (s/coll-of any? :kind vector)
+                      :body (s/* any?))))
+
+(s/def ::expected-fns
+  (s/coll-of ::expected-fn :kind vector?))
+
+(defn mock-call [state var args]
+  (let [ret (atom nil)]
+    ;; put all in swap! to sync mock calls
+    (swap! state
+           (fn [state]
+             (let [var-matches (filter #(= (:mocked-var %) var) state)
+                   [{:keys [tags body-fn calls orig-fn]
+                     :as match} & _] (filter #((:match-fn %) args) var-matches)]
+               ;; report when no matches
+               (cond
+                 (nil? match)
+                 (my-report {:type :fail
+                             :message "found no matching mock!"
+                             :expected (->> var-matches
+                                            (map (fn [{:keys [args mocked-var]}]
+                                                   (list (symbol mocked-var) args)))
+                                            (cons :one-of))
+                             :actual (list (symbol var) args)}
+                            2)
+                 (and (:once tags)
+                      (> calls 0))
+                 (my-report {:type :fail
+                             :message "call with :once tag called more than once"
+                             :actual (list (symbol var) args)}
+                            2))
+
+               (reset! ret
+                       (if (:do ret)
+                         (apply orig-fn args)
+                         (body-fn)))
+
+               (-> state
+                   (disj match)
+                   (conj (update match :calls inc))))))
+    @ret))
+
+(defmacro with-expect-call2 [expected-fns & body]
+  (let [conformed (s/conform ::expected-fns
+                             expected-fns)
+        state-sym (gensym "excpect-call-state")]
+    (when (s/invalid? conformed)
+      (throw (ex-info "expect-call did not conform to spec"
+                      (s/explain-data ::expected-fns
+                                      expected-fns))))
+    `(let [~state-sym
+           (atom ~(->> conformed
+                       (map (fn [{tags                      :tags
+                                  {:keys [fname args body]} :fdef}]
+                              {:mocked-var `(resolve (quote ~fname))
+                               :args       args
+                               :body-fn    `(fn ~'do-body []
+                                              ~@body)
+                               :calls      0
+                               :match-fn   `(fn [args#]
+                                              (match (into [] args#)
+                                                     ~args true
+                                                     :else false))
+                               :orig-fn    fname
+                               :tags       (into #{} tags)}))
+                       (into #{})))]
+       (with-redefs ~(->> conformed
+                          (into #{}
+                                (map (comp :fname :fdef)))
+                          (mapcat (fn [fname]
+                                    [fname
+                                     `(fn [~'& args#]
+                                        (mock-call ~state-sym (resolve (quote ~fname)) args#))]))
+                          (into []))
+         ~@body))))
 
 (defmacro expect-call
   "expected-fns: (fn arg-match body...)
                  or [(fn arg-match body...), (fn arg-match body...)...]
-   Each fn may be preceded by keywords :more, :never or :do."
+   Each fn may be preceded by keywords :more, :never, :once or :do.
+  :more allows fns to be called any number of times in any order
+  :do calls through to the underlying fn, allowing you to expect args
+  :never ensures the fn is never called
+  :once makes the function called once during the duration of the body, allowing any order"
   [expected-fns & body]
 
   `(-expect-call ~expected-fns ~@body))


### PR DESCRIPTION
This is a POC from noticing restrictions of expect-call, not ready for "production".

Restructures how the lib works completely to make it more
extensible and clean. The new version allows unordered mock calls and
can allow for multiple calls of the same fn in any order. Currently the
lib is locked into ordered calls. Requiring ordered calls could be added
to this POC. So far :do :more, and :once are supported. Arg matching
also works as the previous one.

Need to add a post-run check to make sure the mocks are all called.
This should be as easy as checking the number of calls on each of the mocks.

Needs testing