### PR TITLE
lint mixed value matching and sequential destructuring

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,9 +2,9 @@
  :deps {org.clojure/core.match {:mvn/version "1.0.0"}}
  :aliases
  {:test {:extra-paths ["test"]}
-  :hooks {:extra-deps
+  :hooks {:deps
           {clj-kondo/clj-kondo
            {:git/url "https://github.com/clj-kondo/clj-kondo.git"
             :git/tag "v2025.01.16"
             :git/sha "3994c84"}}
-          :extra-paths [".clj-kondo"]}}}
+          :paths ["resources/clj-kondo.exports/whitepages/expect-call"]}}}

--- a/resources/clj-kondo.exports/whitepages/expect-call/hooks/whitepages/expect_call.clj_kondo
+++ b/resources/clj-kondo.exports/whitepages/expect-call/hooks/whitepages/expect_call.clj_kondo
@@ -121,28 +121,75 @@
     (:children expected-fns-node)
     [expected-fns-node]))
 
-(defn sequential-destructuring? [node]
-  (and (api/vector-node? node)
-       (symbol-node? (first (remove api/vector-node? (iterate #(-> % :children first) node))))))
+(defn with-ignore-unresolved  [node]
+  (vary-meta node assoc :clj-kondo/ignore [:unresolved-symbol :unresolved-var]))
 
-(defn ->safe-arg-node
-  "Replace with symbol node if it's a literal value"
-  [arg-node]
-  (if (or (api/map-node? arg-node) ;; map destructuring doesn't seem to be allowed in expect-call
-          (symbol-node? arg-node)
-          (sequential-destructuring? arg-node))
-    arg-node
-    (api/token-node (gensym "_arg"))))
+(letfn
+ [(analyze-rf
+    ([] {:args-node [] :symbol-nodes [] :value-nodes []})
+    ([acc] (update acc :args-node api/vector-node))
+    ([acc arg-node]
+     (cond
+       (symbol-node? arg-node)
+       (merge-with
+        conj acc
+        {:args-node arg-node
+         :symbol-nodes (-> arg-node with-ignore-unresolved)})
 
-(defn redefed-fn [{:keys [children]}]
-  (let [[fn-name-node args-node & body]
-        (into [] (drop-while api/keyword-node?) children)]
+       (api/vector-node? arg-node)
+       (merge-with
+        into acc
+        (update (analyze-argvec- arg-node) :args-node vector))
+
+       (or (api/string-node? arg-node)
+           (api/keyword-node? arg-node))
+       (update acc :args-node conj (api/token-node (gensym "_arg")))
+
+       :else
+       (merge-with
+        conj acc
+        {:args-node (api/token-node (gensym "_arg"))
+         :value-nodes arg-node}))))
+  (analyze-argvec- [args-node]
+    (cond
+      (nil? args-node)
+      {:args-node
+       (api/vector-node [(api/token-node '&) (api/token-node (gensym "_more"))])}
+
+      (empty? (:children args-node))
+      {:args-node args-node}
+
+      :else
+      (analyze-rf (reduce analyze-rf (analyze-rf) (:children args-node)))))]
+  (defn analyze-argvec
+    "Returns an argvec that is safe to use as a binding vector,
+    symbols found during analysis, and literal values found during analysis"
+    [args-node]
+    (analyze-argvec- args-node)))
+
+(defn redefed-fn
+  "Transforms expected fn spec into a pair usable with with-redefs.
+  As it might replace nodes in the argvec, it tries to add statements (prn)
+  that result in registering usage and further analysis for the replaced nodes"
+  [{:keys [children]}]
+  (let [[fn-name-node args-node & body] (into [] (drop-while api/keyword-node?) children)
+        {:keys [args-node #_symbol-nodes value-nodes]} (analyze-argvec args-node)]
     [fn-name-node
      (api/list-node
-      (list*
-       (api/token-node 'fn)
-       (api/vector-node (mapv ->safe-arg-node (:children args-node)))
-       body))]))
+      (->
+       [(api/token-node 'do)]
+       (cond->
+        ;; register usage of symbols that are both in the argvec and are valid just outside
+        ;; check after https://github.com/clj-kondo/clj-kondo/issues/2472
+        #_#_(seq symbol-nodes)
+        (conj (-> (api/list-node (list* (api/token-node `prn) symbol-nodes)) with-ignore-unresolved))
+
+        ;; register use of replaced value nodes so they can be linted too
+        (seq value-nodes)
+        (conj (api/list-node (list* (api/token-node `prn) value-nodes))))
+
+       ;; actual fn definition to have body linted
+       (conj (api/list-node (list* (api/token-node 'fn) args-node body)))))]))
 
 (defn ->with-redefs [expect-call-node]
   (let [[expectations-node & body] (rest (:children expect-call-node))]


### PR DESCRIPTION
```shellsession
; lein test

lein test whitepages.expect-call-test
:error abc

Ran 3 tests containing 10 assertions.
0 failures, 0 errors.

; clj-kondo --lint (clojure -Srepro -Spath) --dependencies --copy-configs
Configs copied:
- .clj-kondo/imports/whitepages/expect-call
[clj-kondo] clojure-1.12.0.jar was already linted, skipping
[clj-kondo] core.specs.alpha-0.4.74.jar was already linted, skipping
[clj-kondo] spec.alpha-0.5.238.jar was already linted, skipping

; clj-kondo --lint src:test:deps.edn:.clj-kondo/config.edn:resources
test/whitepages/expect_call_test.clj:100:11: warning: unused binding foo
test/whitepages/expect_call_test.clj:101:44: warning: unused binding foo
test/whitepages/expect_call_test.clj:104:46: warning: unused binding foo
test/whitepages/expect_call_test.clj:127:13: warning: unused binding foo
test/whitepages/expect_call_test.clj:138:27: warning: unused binding foo
test/whitepages/expect_call_test.clj:143:28: warning: unused binding foo
test/whitepages/expect_call_test.clj:148:28: warning: unused binding foo
test/whitepages/expect_call_test.clj:207:6: warning: Empty expect-call body
linting took 123ms, errors: 0, warnings: 8
```