### PR TITLE
solve unused symbols in lint hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,32 @@ A fork of: https://github.com/meredydd/expect-call
 
 ## Development on this fork
 
+### Running tests
+
+Run tests with `lein test`.
+
+To check compatibility with different versions of Clojure, use the [Leiningen profiles](https://github.com/technomancy/leiningen/blob/master/doc/PROFILES.md#merging:~:text=Another%20use%20of%20profiles%20is%20to%20test%20against%20various%20sets%20of%20dependencies) defined:
+
+```shell
+lein with-profile 1.7 test
+lein with-profile 1.11 test
+
+etc.
+```
+
+Or even:
+
+```shell
+#!/usr/bin/env fish
+
+lein test && for i in (seq 6 12)
+    lein with-profile 1.$i test
+end
+```
+
 ### Bumping dependencies
 
-Update both `deps.edn` and `project.clj` for now.
+Update both `deps.edn` and `project.clj`.
 
 ### Linting
 
@@ -24,16 +47,10 @@ clj-kondo --lint src:test:deps.edn:.clj-kondo/config.edn:resources
 
 Use the `:hooks` alias in your editor/to start your repl. Optional: bump clj-kondo version there.
 
-### Running tests
-
-Use `lein test`. For example:
+Can use the `lint` alias to use a specific clj-kondo version:
 
 ```shell
-#!/usr/bin/env fish
-
-lein test && for i in (seq 6 12)
-    lein with-profile 1.$i test
-end
+clojure -M:lint src:test:deps.edn:.clj-kondo/config.edn:resources
 ```
 
 ## Introduction
@@ -284,7 +301,6 @@ Now, wasn't that so much nicer than dependency injection?
 ## Feedback
 
 Please send feedback and pull requests to `meredydd@senatehouse.org`, or `meredydd` on GitHub.
-
 
 ## License
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,12 @@
   :hooks {:deps
           {clj-kondo/clj-kondo
            {:git/url "https://github.com/clj-kondo/clj-kondo.git"
-            :git/tag "v2025.01.16"
-            :git/sha "3994c84"}}
-          :paths ["resources/clj-kondo.exports/whitepages/expect-call"]}}}
+            :git/tag "v2025.02.20"
+            :git/sha "2f91d3d"}}
+          :paths ["resources/clj-kondo.exports/whitepages/expect-call"]}
+  :lint {:deps
+         {clj-kondo/clj-kondo
+          {:git/url "https://github.com/clj-kondo/clj-kondo.git"
+           :git/tag "v2025.02.20"
+           :git/sha "2f91d3d"}}
+         :main-opts ["-m" "clj-kondo.main" "--parallel" "--lint"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject whitepages/expect-call "0.3.0" ;; NOTE: no longer published
+(defproject whitepages/expect-call "0.3.1" ;; NOTE: no longer published
   :description "A Clojure library for no-fuss function mocking"
   :url "https://github.com/whitepages/expect-call"
   :license {:name "Eclipse Public License"

--- a/resources/clj-kondo.exports/whitepages/expect-call/config.edn
+++ b/resources/clj-kondo.exports/whitepages/expect-call/config.edn
@@ -1,4 +1,5 @@
-{:hooks
+{:min-clj-kondo-version "2025.02.20"
+ :hooks
  {:analyze-call
   {whitepages.expect-call/with-expect-call hooks.whitepages.expect-call/expect-call
    whitepages.expect-call/expect-call hooks.whitepages.expect-call/expect-call}}

--- a/resources/clj-kondo.exports/whitepages/expect-call/hooks/whitepages/expect_call.clj_kondo
+++ b/resources/clj-kondo.exports/whitepages/expect-call/hooks/whitepages/expect_call.clj_kondo
@@ -121,20 +121,17 @@
     (:children expected-fns-node)
     [expected-fns-node]))
 
-(defn with-ignore-unresolved  [node]
-  (vary-meta node assoc :clj-kondo/ignore [:unresolved-symbol :unresolved-var]))
-
 (letfn
  [(analyze-rf
     ([] {:args-node [] :symbol-nodes [] :value-nodes []})
     ([acc] (update acc :args-node api/vector-node))
     ([acc arg-node]
      (cond
-       (symbol-node? arg-node)
+       (and (symbol-node? arg-node) (simple-symbol? (api/sexpr arg-node)))
        (merge-with
         conj acc
         {:args-node arg-node
-         :symbol-nodes (-> arg-node with-ignore-unresolved)})
+         :symbol-nodes arg-node})
 
        (api/vector-node? arg-node)
        (merge-with
@@ -167,39 +164,51 @@
     [args-node]
     (analyze-argvec- args-node)))
 
-(defn redefed-fn
-  "Transforms expected fn spec into a pair usable with with-redefs.
-  As it might replace nodes in the argvec, it tries to add statements (prn)
-  that result in registering usage and further analysis for the replaced nodes"
-  [{:keys [children]}]
-  (let [[fn-name-node args-node & body] (into [] (drop-while api/keyword-node?) children)
-        {:keys [args-node #_symbol-nodes value-nodes]} (analyze-argvec args-node)]
-    [fn-name-node
-     (api/list-node
-      (->
-       [(api/token-node 'do)]
-       (cond->
-        ;; register usage of symbols that are both in the argvec and are valid just outside
-        ;; check after https://github.com/clj-kondo/clj-kondo/issues/2472
-        #_#_(seq symbol-nodes)
-        (conj (-> (api/list-node (list* (api/token-node `prn) symbol-nodes)) with-ignore-unresolved))
+(let [drop-while-keyword-xf
+      (drop-while api/keyword-node?)
 
-        ;; register use of replaced value nodes so they can be linted too
-        (seq value-nodes)
-        (conj (api/list-node (list* (api/token-node `prn) value-nodes))))
+      ->resolved-symbols-xf
+      (comp (map api/sexpr)
+            (filter #(or (api/resolve {:name %})
+                         (contains? (api/env) %))))
 
-       ;; actual fn definition to have body linted
-       (conj (api/list-node (list* (api/token-node 'fn) args-node body)))))]))
+      ->fake-use-node
+      (fn [nodes]
+        (api/list-node (list* (api/token-node `prn) nodes)))]
+  (defn redefed-fn
+    "Transforms expected fn spec into a pair usable with with-redefs.
+    As it might replace nodes in the argvec, it tries to add fake statements (prn)
+    that result in registering usage and further analysis for the replaced nodes"
+    [{:keys [children]}]
+    (let [[fn-name-node args-node & body] (into [] drop-while-keyword-xf children)
+          {:keys [args-node symbol-nodes value-nodes]} (analyze-argvec args-node)
+          resolved-symbols (into [] ->resolved-symbols-xf symbol-nodes)
+          register-use-inside (mapv api/token-node resolved-symbols)
+          register-use-outside (into register-use-inside value-nodes)]
+      [fn-name-node
+       (-> [(api/token-node 'fn) args-node] ;; (fn [...]
+           (cond->
+            ;; register usage of symbols that are both in the argvec and are valid just outside
+            (seq register-use-inside)
+            (conj (->fake-use-node register-use-inside))) ;; (prn a b c)
+           (conj body) ;; original fn body
+           (as-> $ (api/list-node (apply list* $))) ;; make it a list node
+           (cond->
+            ;; register usage of symbols that are both in the argvec and are valid just outside, or got replaced
+            (seq register-use-outside)
+            ;; wrap with (do (prn a b c) (fn...))
+            (as-> $ (api/list-node [(api/token-node 'do) (->fake-use-node register-use-outside) $]))))])))
 
-(defn ->with-redefs [expect-call-node]
-  (let [[expectations-node & body] (rest (:children expect-call-node))]
-    (-> expectations-node
-        (->expected-fn-nodes)
-        (->> (into [] (mapcat redefed-fn)))
-        (api/vector-node)
-        (as-> $ (list* (api/token-node 'with-redefs) $ body))
-        (api/list-node)
-        #_(doto (-> api/sexpr prn)))))
+(let [mapcat-redefed-fn-xf (mapcat redefed-fn)]
+  (defn ->with-redefs [expect-call-node]
+    (let [[expectations-node & body] (rest (:children expect-call-node))]
+      (-> expectations-node
+          (->expected-fn-nodes)
+          (->> (into [] mapcat-redefed-fn-xf))
+          (api/vector-node)
+          (as-> $ (list* (api/token-node 'with-redefs) $ body))
+          (api/list-node)
+          #_(doto (-> api/sexpr prn))))))
 
 ;; endregion transformation
 

--- a/test/whitepages/expect_call_test.clj
+++ b/test/whitepages/expect_call_test.clj
@@ -204,7 +204,7 @@
 
   (testing "Not called"
     (check-line
-     (sut/with-expect-call (log))))
+     (sut/with-expect-call (log) (inc 1))))
 
   (testing "Wrong function"
     (check-line (sut/with-expect-call [(log) (println)] (println "hi"))))


### PR DESCRIPTION
Without the last commit in this patch symbols in the expected function's arglist might show up unused:

```
; clj-kondo --lint test
test/whitepages/expect_call_test.clj:100:11: warning: unused binding foo
test/whitepages/expect_call_test.clj:101:44: warning: unused binding foo
test/whitepages/expect_call_test.clj:104:46: warning: unused binding foo
test/whitepages/expect_call_test.clj:127:13: warning: unused binding foo
test/whitepages/expect_call_test.clj:138:27: warning: unused binding foo
test/whitepages/expect_call_test.clj:143:28: warning: unused binding foo
test/whitepages/expect_call_test.clj:148:28: warning: unused binding foo
linting took 28ms, errors: 0, warnings: 7
```

With this patch it is solved:

```
; clj-kondo --lint test
linting took 22ms, errors: 0, warnings: 0
```